### PR TITLE
Add Security and License Scans Workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,82 @@
+name: Security and License Scans
+
+on:
+  workflow_call:
+
+jobs:
+  fossa-scan:
+    name: FOSSA Scanning Kickoff
+    runs-on: ubuntu-latest
+    outputs:
+      fossaScanResults: ${{ steps.fossa_test.outputs.results }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Run FOSSA Scan
+        uses: fossas/fossa-action@main
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+
+      - name: Run FOSSA Test
+        id: fossa_test
+        env:
+          FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+        run: |
+          MAIN_BRANCH="main"
+          MAIN_BRANCH_REF="refs/heads/$MAIN_BRANCH"
+          CURRENT_BRANCH_REF="${{ github.ref }}"
+          DIFF_OPTION=""
+
+          if [ "$CURRENT_BRANCH_REF" != "$MAIN_BRANCH_REF" ]; then
+            git fetch origin $MAIN_BRANCH
+            MAIN_SHA=$(git rev-parse origin/$MAIN_BRANCH)
+            DIFF_OPTION="--diff $MAIN_SHA"
+          fi
+
+          fossa test --format json $DIFF_OPTION | tee fossa-test.json
+
+          FOSSA_RESULTS=$(cat fossa-test.json)
+          if [ -z "$FOSSA_RESULTS" ]; then
+            echo "Failed to generate FOSSA Scanning Results"
+            exit 1
+          fi
+
+          echo "results=$FOSSA_RESULTS" >> $GITHUB_OUTPUT
+
+  fossa-security-check:
+    name: FOSSA Security Check
+    needs: fossa-scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Security Issues
+        run: |
+          ISSUES=$(echo '${{ needs.fossa-scan.outputs.fossaScanResults }}' | jq '.issues | map(select(.type | IN("unlicensed_dependency", "policy_conflict", "policy_flag") | not))')
+          ISSUES_LEN=$(echo $ISSUES | jq length)
+          if [ $ISSUES_LEN -gt 0 ]; then
+            echo "FOSSA Security Check failed"
+            echo "Issues found:\n$ISSUES"
+            cat fossa-test.json
+            exit 1
+          fi
+
+  fossa-license-check:
+    name: FOSSA Licenses Check
+    needs: fossa-scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check License Issues
+        run: |
+          ISSUES=$(echo '${{ needs.fossa-scan.outputs.fossaScanResults }}' | jq '.issues | map(select(.type | IN("unlicensed_dependency", "policy_conflict", "policy_flag")))')
+          ISSUES_LEN=$(echo $ISSUES | jq length)
+          if [ $ISSUES_LEN -gt 0 ]; then
+            echo "FOSSA License Check failed"
+            echo "Issues found: $ISSUES"
+            cat fossa-test.json
+            exit 1
+          fi

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,11 +9,7 @@
 # The format is described: https://github.blog/2017-07-06-introducing-code-owners/
 
 # These owners will be the default owners for everything in the repo.
-*       @ALRubinger
-*       @csuwildcat
-*       @decentralgabe
-*       @hdou731
-*       @mistermoe
+* @ALRubinger @leordev @dayhaysoos @finn-tbd
 
 
 # -----------------------------------------------

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ The [contribution guide](./CONTRIBUTING.md) welcomes contributors with resources
 | [`dwn-sdk-js`](https://github.com/TBD54566975/dwn-sdk-js)         | TypeScript | An implementation of the DIF's emerging decentralized personal datastore standard.                                                        |
 | [`tbdex-protocol`](https://github.com/TBD54566975/tbdex-protocol) | Java       | A playground as we iterate our way to a robust protocol. Mostly composed of tbDEX message schemas/formats and a mock PFI implemementaion. |
 
+## Reusable Workflows
+
+TBD uses GitHub Actions for our repository pipelines. Some checks, such as Security and License Scans, are identical across all our project repositories. Therefore, you can find these shared workflows in the [.github/workflows](./.github/workflows) directory.
+
 ## Project Resources
 
 | Resource                                   | Description                                                                   |


### PR DESCRIPTION
- Introduces the Security Workflow to be reused across TBD. 
- Updates readme with relevant info
- Update CODEOWNERS to reflect current OSP team

Working evidence: https://github.com/TBD54566975/developer.tbd.website/actions/runs/8396136683?pr=1348