### PR TITLE
Fix FOSSA diff checks

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,10 +26,12 @@ jobs:
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
         run: |
+          DIFF_OPTION=""
           MAIN_BRANCH="main"
           MAIN_BRANCH_REF="refs/heads/$MAIN_BRANCH"
-          CURRENT_BRANCH_REF="${{ github.ref }}"
-          DIFF_OPTION=""
+
+          CURRENT_BRANCH_REF="${{ github.head_ref || github.ref }}"
+          echo "Current Branch: $CURRENT_BRANCH_REF"
 
           if [ "$CURRENT_BRANCH_REF" != "$MAIN_BRANCH_REF" ]; then
             git fetch origin $MAIN_BRANCH
@@ -37,7 +39,9 @@ jobs:
             DIFF_OPTION="--diff $MAIN_SHA"
           fi
 
-          fossa test --format json $DIFF_OPTION | tee fossa-test.json
+          CMD="fossa test --format json $DIFF_OPTION"
+          echo "Running FOSSA Test with command: '$CMD'"
+          $CMD | tee fossa-test.json
 
           FOSSA_RESULTS=$(cat fossa-test.json)
           if [ -z "$FOSSA_RESULTS" ]; then
@@ -60,7 +64,7 @@ jobs:
           if [ $ISSUES_LEN -gt 0 ]; then
             echo "FOSSA Security Check failed"
             echo "Issues found:\n$ISSUES"
-            cat fossa-test.json
+            echo '${{ needs.fossa-scan.outputs.fossaScanResults }}'
             exit 1
           fi
 
@@ -77,6 +81,6 @@ jobs:
           if [ $ISSUES_LEN -gt 0 ]; then
             echo "FOSSA License Check failed"
             echo "Issues found: $ISSUES"
-            cat fossa-test.json
+            echo '${{ needs.fossa-scan.outputs.fossaScanResults }}'
             exit 1
           fi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,6 +3,8 @@ name: Security and License Scans
 on:
   workflow_call:
 
+permissions: read-all
+
 jobs:
   fossa-scan:
     name: FOSSA Scanning Kickoff

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           ref: ${{ github.head_ref }}
 
       - name: Run FOSSA Scan
-        uses: fossas/fossa-action@main
+        uses: fossas/fossa-action@47ef11b1e1e3812e88dae436ccbd2d0cbd1adab0 # v1.3.3
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
         run: |
-          set +x
+          set -x
           DIFF_OPTION=""
           MAIN_BRANCH="main"
           MAIN_BRANCH_REF="refs/heads/$MAIN_BRANCH"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,8 +3,6 @@ name: Security and License Scans
 on:
   workflow_call:
 
-permissions: read-all
-
 jobs:
   fossa-scan:
     name: FOSSA Scanning Kickoff

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,6 +26,7 @@ jobs:
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
         run: |
+          set +x
           DIFF_OPTION=""
           MAIN_BRANCH="main"
           MAIN_BRANCH_REF="refs/heads/$MAIN_BRANCH"
@@ -39,9 +40,7 @@ jobs:
             DIFF_OPTION="--diff $MAIN_SHA"
           fi
 
-          CMD="fossa test --format json $DIFF_OPTION"
-          echo "Running FOSSA Test with command: '$CMD'"
-          $CMD | tee fossa-test.json
+          fossa test --format json $DIFF_OPTION | tee fossa-test.json
 
           FOSSA_RESULTS=$(cat fossa-test.json)
           if [ -z "$FOSSA_RESULTS" ]; then


### PR DESCRIPTION
I noticed a bug when running the workflow using the event `pull_request_target`. Here's the fix for that.

This is what is expected per event trigger:

Main checks
- `push main` -> `fossa test --format json`
    - evidence: https://github.com/leordev/web5-js-releases2/actions/runs/8452746155/job/23153812076#step:3:22
- manual dispatch on main -> `fossa test --format json`
    - evidence: https://github.com/leordev/web5-js-releases2/actions/runs/8452763945/job/23153877455#step:3:22

Branches diff checks
- manual dispatch on a PR branch -> `fossa test --format json --diff $MAIN_SHA`
    - evidence: https://github.com/leordev/web5-js-releases2/actions/runs/8452897108/job/23154338513#step:3:25
- PR triggered with `pull_request` event -> `fossa test --format json --diff $MAIN_SHA`
    - evidence: https://github.com/leordev/web5-js-releases2/actions/runs/8452892824/job/23154324619?pr=5#step:3:25
- PR triggered with `pull_request_target` event -> `fossa test --format json --diff $MAIN_SHA`
    - evidence: https://github.com/leordev/web5-js-releases2/actions/runs/8452892746/job/23154324185?pr=5#step:3:25