### PR TITLE
Always run FOSSA on non-PRs

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       fossaScanResults: ${{ steps.fossa_test.outputs.results }}
 
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository }}
       
     steps:
       - name: Checkout
@@ -57,7 +57,7 @@ jobs:
     needs: fossa-scan
     runs-on: ubuntu-latest
 
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository }}
 
     steps:
       - name: Check Security Issues
@@ -76,7 +76,7 @@ jobs:
     needs: fossa-scan
     runs-on: ubuntu-latest
 
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository }}
 
     steps:
       - name: Check License Issues


### PR DESCRIPTION
Previous condition was preventing the FOSSA jobs from running on events that weren't PR-related (`github.event.pull_request` wasnt set).

Tested:
* [identical conditional on job config](https://github.com/finn-tbd-test-org/.github/blob/main/.github/workflows/checkout-test.yml#L40)
* [job in response to manual event](https://github.com/finn-tbd-test-org/example-repo/actions/runs/8622105331/job/23632498996)